### PR TITLE
Add protocol schema and flow description

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,0 +1,63 @@
+## Protocol Description
+
+This protocol facilitates privacy-preserving surveys using Waku.
+
+### Roles in the protocol:
+- **Researcher**: Creates and distributes surveys, collects responses, and optionally publishes results.
+- **Respondent**: Receives survey notifications, submits encrypted responses.
+
+### Protocol Flow:
+1. The Researcher posts a `SurveyCreate` message over Waku.
+2. The Respondent:
+   - Decodes the `SurveyCreate` message.
+   - Generates a `SurveyResponse`, encrypting responses with the survey's public key.
+   - Posts the `SurveyResponse` to the Waku topic.
+3. The Researcher collects and aggregates responses.
+4. *(Optional)* The Researcher posts a `SurveyClose` message to close the survey and indicate a deadline.
+5. *(Optional)* The Researcher posts a `SurveyResults` message with aggregated results.
+
+---
+
+```proto
+syntax = "proto3";
+
+message SurveyCreate {
+    string survey_id = 1;
+    repeated FormQuestion survey_questions = 2;
+    bytes survey_pub_key = 3;
+    optional string survey_eligibility_requirements = 4;
+    optional uint64 survey_deadline = 5;
+}
+
+message FormQuestion {
+    enum SurveyQuestionType {
+        TEXT = 0;
+        SINGLE_CHOICE = 1;
+        MULTI_CHOICE = 2;
+    }
+    SurveyQuestionType question_type = 1;
+    string survey_question = 2;
+    repeated string survey_options = 3; // Optional
+}
+
+message SurveyResponse {
+    string response_id = 1;
+    bytes encrypted_survey_response_payload = 2;
+}
+
+message SurveyResponsePayload {
+    string survey_id = 1;
+    bytes survey_response = 2;
+    optional bytes survey_eligibility_proof = 3; // ZKP, signature, etc.
+}
+
+message SurveyClose {
+    string survey_id = 1;
+    uint64 timestamp = 2;
+}
+
+message SurveyResults {
+    string survey_id = 1;
+    bytes aggregated_results = 2;
+}
+```

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,30 +1,30 @@
 ## Protocol Description
 
-WhisperBox is a privacy-preserving survey protocol based on Waku. Surveys are widely used for research and collecting feedback, but they are typically hosted on centralized platforms that require trust. Privacy is essential for surveys to collect reliable data, especially on controversial subjects. The ephemeral nature of Waku helps achieve this privacy.
+WhisperBox is a privacy-preserving survey protocol based on Waku. Forms are widely used for research and collecting feedback, but they are typically hosted on centralized platforms that require trust. Privacy is essential for surveys (aka forms) to collect reliable data, especially on controversial subjects. The ephemeral nature of Waku helps achieve this privacy.
 
 ### Security Model
-The primary goal of the protocol is to preserve the privacy of respondents from external observers. Only the researcher (survey creator) must be able to decrypt the responses. The researcher will see the responses in clear text, which aligns with our security assumptions. However, the researcher must not be able to infer additional privacy-related data from the responses, such as the IP address or location of the respondent.
+The primary goal of the protocol is to preserve the privacy of respondents from external observers. Only the researcher (form creator) must be able to decrypt the responses. The researcher will see the responses in clear text, which aligns with our security assumptions. However, the researcher must not be able to infer additional privacy-related data from the responses, such as the IP address or location of the respondent.
 
-In research, some responses are typically discarded (e.g., outliers). The protocol does not enforce consideration of all responses. Confirmation of receipt is possible, but confirmation of consideration is not required. The researcher is trusted to tally the results reasonably. They may optionally publish aggregated survey results in the same Waku topic but are not required to prove how responses were handled.
+In research, some responses are typically discarded (e.g., outliers). The protocol does not enforce consideration of all responses. Confirmation of receipt is possible, but confirmation of consideration is not required. The researcher is trusted to tally the results reasonably. They may optionally publish aggregated form results in the same Waku topic but are not required to prove how responses were handled.
 
 ### Roles in the protocol:
-- **Researcher**: Creates and distributes surveys, collects responses, and optionally publishes results.
-- **Respondent**: Receives survey notifications, submits encrypted responses.
+- **Researcher**: Creates and distributes forms, collects responses, and optionally publishes results.
+- **Respondent**: Receives form notifications, submits encrypted responses.
 
 ### Protocol Flow:
-1. The Researcher posts a `Survey` message over Waku.
+1. The Researcher posts a `Form` message over Waku.
 2. The Respondent:
-   - Decodes the `Survey` message.
-   - Generates a `SurveyResponse`, encrypting responses with the survey's public key.
-   - Posts the `SurveyResponse` to the Waku topic.
+   - Decodes the `Form` message.
+   - Generates a `FormResponse`, encrypting responses with the form's public key.
+   - Posts the `FormResponse` to the Waku topic.
 3. The Researcher collects and aggregates responses.
-4. *(Optional)* The Researcher posts a `SurveyClose` message to close the survey and indicate a deadline.
-5. *(Optional)* The Researcher posts a `SurveyResults` message with aggregated results.
+4. *(Optional)* The Researcher posts a `FormClose` message to close the form and indicate a deadline.
+5. *(Optional)* The Researcher posts a `FormResults` message with aggregated results.
 
 ### Encryption Modes
 There are three security modes:
 1. **Unencrypted**: All data is transparent. Generally not recommended but may work for non-sensitive use cases. Respondents should avoid including personally identifiable data.
-2. **Encrypted responses**: The survey is public, but responses are encrypted using the researcher's public key. Only the researcher can decrypt responses.
+2. **Encrypted responses**: The form is public, but responses are encrypted using the researcher's public key. Only the researcher can decrypt responses.
 3. **Encrypted and authenticated responses**: In addition to encryption, respondents include a proof of eligibility in their responses. This allows the researcher to limit participants, e.g., requiring a wallet in the response. Advanced setups may use zero-knowledge proofs of membership or signatures proving ownership of a token (NFT, Ordinal).
 
 ### Protocol Schema
@@ -32,58 +32,77 @@ There are three security modes:
 ```proto
 syntax = "proto3";
 
-enum QuestionType {
-    TEXT = 0;
-    SINGLE_CHOICE = 1;
-    MULTI_CHOICE = 2;
-}
-
 message Question {
-    uint32 question_index = 1;
-    QuestionType question_type = 2;
-    string question = 3;
-    repeated string question_options = 4;  // for choice-based questions
+    enum Type {
+        TEXT = 0;
+        TEXT_AREA = 1;
+        SINGLE_CHOICE = 2;
+        MULTIPLE_CHOICE = 3;
+    }
+    string id = 1;
+    Type type = 2;
+    string text = 3;
+    bool required = 4;
+    repeated string options = 5;  // for choice-based questions
 }
 
-message Answer {
-    uint32 question_index = 1;
-    optional string answer_text = 2;  // for text-based questions
-    repeated uint32 answer_options = 3;  // for choice-based questions
+message Form {
+    message Whitelist {
+        enum Type {
+            NFT = 0;
+            ADDRESSES = 1;
+            NONE = 2;
+        }
+        Type type = 1;
+        string value = 2;
+    }
+    string id = 1;
+    optional string title = 2;
+    optional string description = 3;
+    optional string creator = 4;
+    uint64 created_at = 5;
+    optional uint64 expires_at = 6;
+    repeated Question questions = 7;
+    Whitelist whitelist = 8;
+    repeated FormResponse responses = 9;
 }
 
-message Survey {
-    string survey_id = 1;
-    repeated Question survey_questions = 2;
-    bytes survey_pub_key = 3;
-    optional string survey_eligibility_requirements = 4;
-    optional uint64 survey_deadline = 5;
+message FormResponse {
+    message Answer {
+        string question_id = 1;
+        oneof value {
+            string text = 2;
+            uint32 option = 3;
+            repeated uint32 options = 4;
+        }
+    }
+    string id = 1;  // response ID
+    string form_id = 2;   // form ID that this response relates to
+    string respondent = 3;
+    optional string respondent_ENS = 4;
+    uint64 submitted_at = 5;
+    repeated Answer answers = 6;
 }
 
-message SurveyResponse {
-    string survey_id = 1;
-    repeated Answer survey_answers = 2;
-    optional bytes survey_eligibility_proof = 3; // ZKP, signature, etc.
+message FormResponseEncrypted {
+    string form_id = 1;
+    bytes response_encrypted = 2;
+    optional string encryption_scheme = 3;  // Optional: specify encryption method
 }
 
-message SurveyResponseEncrypted {
-    string survey_id = 1;
-    bytes survey_response_encrypted = 2;
-    string encryption_scheme = 3;  // Optional: specify encryption method
+message FormClose {
+    string form_id = 1;
+    uint64 expires_at = 2;
 }
 
-message SurveyClose {
-    string survey_id = 1;
-    uint64 timestamp = 2;
-}
-
-message SurveyResults {
-    string survey_id = 1;
+message FormResults {
+    string form_id = 1;
     bytes aggregated_results = 2;
 }
 ```
 
 ### Future Work
-- Improve survey discoverability via Waku announcements or external websites.
+- Improve form discoverability via Waku announcements or external websites.
 - Add spam protection using RLN, in addition to optional respondent whitelisting, ensuring that each eligible respondent can respond at most once (related: Semaphore protocol).
 - Enable respondents to prove they have participated without revealing extra information.
 - Provide a mechanism for respondents to verify that their response has been considered, while recognizing that researchers may discard responses as part of normal data processing (e.g., outliers, spam, incomplete responses).

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,6 +1,11 @@
 ## Protocol Description
 
-This protocol facilitates privacy-preserving surveys using Waku.
+WhisperBox is a privacy-preserving survey protocol based on Waku. Surveys are widely used for research and collecting feedback, but they are typically hosted on centralized platforms that require trust. Privacy is essential for surveys to collect reliable data, especially on controversial subjects. The ephemeral nature of Waku helps achieve this privacy.
+
+### Security Model
+The primary goal of the protocol is to preserve the privacy of respondents from external observers. Only the researcher (survey creator) must be able to decrypt the responses. The researcher will see the responses in clear text, which aligns with our security assumptions. However, the researcher must not be able to infer additional privacy-related data from the responses, such as the IP address or location of the respondent.
+
+In research, some responses are typically discarded (e.g., outliers). The protocol does not enforce consideration of all responses. Confirmation of receipt is possible, but confirmation of consideration is not required. The researcher is trusted to tally the results reasonably. They may optionally publish aggregated survey results in the same Waku topic but are not required to prove how responses were handled.
 
 ### Roles in the protocol:
 - **Researcher**: Creates and distributes surveys, collects responses, and optionally publishes results.
@@ -15,6 +20,12 @@ This protocol facilitates privacy-preserving surveys using Waku.
 3. The Researcher collects and aggregates responses.
 4. *(Optional)* The Researcher posts a `SurveyClose` message to close the survey and indicate a deadline.
 5. *(Optional)* The Researcher posts a `SurveyResults` message with aggregated results.
+
+### Encryption Modes
+There are three security modes:
+1. **Unencrypted**: All data is transparent. Generally not recommended but may work for non-sensitive use cases. Respondents should avoid including personally identifiable data.
+2. **Encrypted responses**: The survey is public, but responses are encrypted using the researcher's public key. Only the researcher can decrypt responses.
+3. **Encrypted and authenticated responses**: In addition to encryption, respondents include a proof of eligibility in their responses. This allows the researcher to limit participants, e.g., requiring a wallet in the response. Advanced setups may use zero-knowledge proofs of membership or signatures proving ownership of a token (NFT, Ordinal).
 
 ---
 
@@ -61,3 +72,13 @@ message SurveyResults {
     bytes aggregated_results = 2;
 }
 ```
+
+### Future Work
+- Improve survey discoverability via Waku announcements or external websites.
+- Add spam protection using RLN, in addition to optional respondent whitelisting, ensuring that each eligible respondent can respond at most once (related: Semaphore protocol).
+- Enable respondents to prove they have participated without revealing extra information.
+- Provide a mechanism for respondents to verify that their response has been considered, while recognizing that researchers may discard responses as part of normal data processing (e.g., outliers, spam, incomplete responses).
+
+### Related Work
+- **Qaku** - Q&A over Waku: [https://qaku.app/](https://qaku.app/)
+- **Megaphone** - Forms-based platform: [https://www.megaphone.xyz/forms](https://www.megaphone.xyz/forms) (requires login via centralized email provider, making it unsuitable for privacy-focused use cases)

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -18,7 +18,7 @@ export interface FormType {
   publicKey: string;
   privateKey: string;
   createdAt: number;
-  expiresAt?: string; // Optional expiry timestamp
+  expiresAt?: number; // Optional expiry timestamp
   questions: FormQuestion[];
   whitelist: {
     type: 'nft' | 'addresses' | 'none';
@@ -38,7 +38,7 @@ export interface FormResponse {
   signature: string;
   answers: {
     questionId: string;
-    value: string | string[];
+    value: string | number | number[];
   }[];
   confirmationId: string | null;
 }

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -38,7 +38,7 @@ export interface FormResponse {
   signature: string;
   answers: {
     questionId: string;
-    value: string | number | number[];
+    value: string | string[];
   }[];
   confirmationId: string | null;
 }


### PR DESCRIPTION
This PR adds a markdown file that describes the protocol flow and defines message types in terms of protobuf. Addresses #3 (but doesn't close it as it contains no serialisation and deserialisation code).