### PR TITLE
add encryption and response confirmations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
         "@tanstack/react-query": "^5.56.2",
+        "@waku/message-encryption": "0.0.32-09108d9.0",
         "@waku/sdk": "0.0.30-09108d9.0",
         "caniuse-lite": "^1.0.30001706",
         "class-variance-authority": "^0.7.1",
@@ -523,6 +524,8 @@
     "@waku/enr": ["@waku/enr@0.0.28-09108d9.0", "", { "dependencies": { "@ethersproject/rlp": "^5.7.0", "@libp2p/crypto": "^5.0.1", "@libp2p/peer-id": "^5.0.1", "@multiformats/multiaddr": "^12.0.0", "@noble/secp256k1": "^1.7.1", "@waku/utils": "0.0.22-09108d9.0", "debug": "^4.3.4", "js-sha3": "^0.9.2" } }, "sha512-l08sCTaaBPFE09gPvOxgaxBbcbVs4cQ6ERmdJxY3PTXyeK91VMSRBR8wrFFQjAOswDCYZAKtztaQLqAQrhevLA=="],
 
     "@waku/interfaces": ["@waku/interfaces@0.0.29-09108d9.0", "", { "dependencies": { "@waku/proto": "0.0.9-09108d9.0" } }, "sha512-pc8/8lhbrNshRab6G0miK5g7f96piHJ+VwXmMJi9lA9WGLRIIvXCaagwAnLrFPcEU33lrr1SwSTkQwqCrFlfXw=="],
+
+    "@waku/message-encryption": ["@waku/message-encryption@0.0.32-09108d9.0", "", { "dependencies": { "@noble/secp256k1": "^1.7.1", "@waku/core": "0.0.34-09108d9.0", "@waku/interfaces": "0.0.29-09108d9.0", "@waku/proto": "0.0.9-09108d9.0", "@waku/utils": "0.0.22-09108d9.0", "debug": "^4.3.4", "js-sha3": "^0.9.2", "uint8arrays": "^5.0.1" } }, "sha512-1UQFimVvVGeaRS+PBOpuMVGNSE2e1WeCuPZkQzSN9wbIuvTxkomlDfwyCgnQxBDC+6ZetH63KUyY8qaDrSL+HA=="],
 
     "@waku/message-hash": ["@waku/message-hash@0.1.18-09108d9.0", "", { "dependencies": { "@noble/hashes": "^1.3.2", "@waku/utils": "0.0.22-09108d9.0" } }, "sha512-kI1tNZrl+VU9516SD+l557RbJZ7MlAWtDyuvAlYaQtsHCSCwRXAYgbH7Lie2DIvkKaJxtBHLuGR1fDdkP9cGAQ=="],
 
@@ -1254,9 +1257,15 @@
 
     "waku-dispatcher/@libp2p/logger": ["@libp2p/logger@5.1.13", "", { "dependencies": { "@libp2p/interface": "^2.7.0", "@multiformats/multiaddr": "^12.3.3", "interface-datastore": "^8.3.1", "multiformats": "^13.3.1", "weald": "^1.0.4" } }, "sha512-JKyMlySG8T+LpItsj9Vma57yap/A0HqJ8ZdaHvgdoThhSOfqcRs8oRWO/2EG0Q5hUXugw//EAT+Ptj8MyNdbjQ=="],
 
+    "waku-dispatcher/@libp2p/multistream-select": ["@libp2p/multistream-select@6.0.20", "", { "dependencies": { "@libp2p/interface": "^2.7.0", "it-length-prefixed": "^10.0.1", "it-length-prefixed-stream": "^1.2.0", "it-stream-types": "^2.0.2", "p-defer": "^4.0.1", "race-signal": "^1.1.2", "uint8-varint": "^2.0.4", "uint8arraylist": "^2.4.8", "uint8arrays": "^5.1.0" } }, "sha512-DHObPodBZXNUFiMzMX0KSnkbDM6am4G8GfkfYPpmx+yuleuutiJrmN95Xt9ximhn9m+YtEZWB2Je8+Lb0bwIYQ=="],
+
     "waku-dispatcher/@libp2p/peer-collections": ["@libp2p/peer-collections@6.0.25", "", { "dependencies": { "@libp2p/interface": "^2.7.0", "@libp2p/peer-id": "^5.1.0", "@libp2p/utils": "^6.6.0", "multiformats": "^13.3.1" } }, "sha512-sU6mjwANQvVPgTgslRZvxZ6cYzQJ66QmNHm6mrM0cx03Yf1heWnvL28N/P781nGsUjo1cJD7xB5ctAGk6A/lXw=="],
 
     "waku-dispatcher/@libp2p/peer-id": ["@libp2p/peer-id@5.1.0", "", { "dependencies": { "@libp2p/crypto": "^5.0.15", "@libp2p/interface": "^2.7.0", "multiformats": "^13.3.1", "uint8arrays": "^5.1.0" } }, "sha512-9Xob9DDg1uBboM2QvJ5nyPbsjxsNS9obmGAYeAtLSx5aHAIC4AweJQFHssUUCfW7mufkzX/s3zyR62XPR4SYyQ=="],
+
+    "waku-dispatcher/@libp2p/peer-record": ["@libp2p/peer-record@8.0.25", "", { "dependencies": { "@libp2p/crypto": "^5.0.15", "@libp2p/interface": "^2.7.0", "@libp2p/peer-id": "^5.1.0", "@libp2p/utils": "^6.6.0", "@multiformats/multiaddr": "^12.3.3", "multiformats": "^13.3.1", "protons-runtime": "^5.5.0", "uint8-varint": "^2.0.4", "uint8arraylist": "^2.4.8", "uint8arrays": "^5.1.0" } }, "sha512-IFuAhxzMS/NlXZS7+vn7tTJY32ODtKN/aFBRd1wekAw5DebGtvqkt9mN3UbeXJPesu9w87e4Q8GSarD0URXRlw=="],
+
+    "waku-dispatcher/@libp2p/peer-store": ["@libp2p/peer-store@11.1.2", "", { "dependencies": { "@libp2p/crypto": "^5.0.15", "@libp2p/interface": "^2.7.0", "@libp2p/peer-id": "^5.1.0", "@libp2p/peer-record": "^8.0.25", "@multiformats/multiaddr": "^12.3.3", "interface-datastore": "^8.3.1", "it-all": "^3.0.6", "mortice": "^3.0.6", "multiformats": "^13.3.1", "protons-runtime": "^5.5.0", "uint8arraylist": "^2.4.8", "uint8arrays": "^5.1.0" } }, "sha512-2egfDs6j+uvreBrzChf5xwNe0kQgYhuaOBx3rVgCAHxuJyXK6/lK+PpEH3Cfgad+if388mII58MU5gzpbawsaw=="],
 
     "waku-dispatcher/@libp2p/ping": ["@libp2p/ping@2.0.1", "", { "dependencies": { "@libp2p/crypto": "^5.0.1", "@libp2p/interface": "^2.0.1", "@libp2p/interface-internal": "^2.0.1", "@multiformats/multiaddr": "^12.2.3", "it-first": "^3.0.6", "it-pipe": "^3.0.1", "uint8arrays": "^5.1.0" } }, "sha512-KWbzFRDBJyZDd8FziW1N9UKHBcOm2RIVyX7sQh1tFeJ0XpWkNT3IcljOG1STikXTuCXIZmMgan/LrZ+SvJSIGw=="],
 
@@ -1265,6 +1274,8 @@
     "waku-dispatcher/@multiformats/dns": ["@multiformats/dns@1.0.6", "", { "dependencies": { "@types/dns-packet": "^5.6.5", "buffer": "^6.0.3", "dns-packet": "^5.6.1", "hashlru": "^2.3.0", "p-queue": "^8.0.1", "progress-events": "^1.0.0", "uint8arrays": "^5.0.2" } }, "sha512-nt/5UqjMPtyvkG9BQYdJ4GfLK3nMqGpFZOzf4hAmIa0sJh2LlS9YKXZ4FgwBDsaHvzZqR/rUFIywIc7pkHNNuw=="],
 
     "waku-dispatcher/@multiformats/multiaddr": ["@multiformats/multiaddr@12.4.0", "", { "dependencies": { "@chainsafe/is-ip": "^2.0.1", "@chainsafe/netmask": "^2.0.0", "@multiformats/dns": "^1.0.3", "multiformats": "^13.0.0", "uint8-varint": "^2.0.1", "uint8arrays": "^5.0.0" } }, "sha512-FL7yBTLijJ5JkO044BGb2msf+uJLrwpD6jD6TkXlbjA9N12+18HT40jvd4o5vL4LOJMc86dPX6tGtk/uI9kYKg=="],
+
+    "waku-dispatcher/@multiformats/multiaddr-matcher": ["@multiformats/multiaddr-matcher@1.6.0", "", { "dependencies": { "@chainsafe/is-ip": "^2.0.1", "@multiformats/multiaddr": "^12.0.0", "multiformats": "^13.0.0" } }, "sha512-E77lLvQR+50kTAfvjV3g4wr9qCu77Z+6yT0s1hgfh8B4sAXZ8u/YdQJGhjgstgW1kmGy7BXPppROKYijqQsesQ=="],
 
     "waku-dispatcher/@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
 
@@ -1277,6 +1288,8 @@
     "waku-dispatcher/@types/dns-packet": ["@types/dns-packet@5.6.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q=="],
 
     "waku-dispatcher/@types/node": ["@types/node@22.13.10", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw=="],
+
+    "waku-dispatcher/@types/retry": ["@types/retry@0.12.2", "", {}, "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="],
 
     "waku-dispatcher/@waku/core": ["@waku/core@0.0.34-09108d9.0", "", { "dependencies": { "@libp2p/ping": "2.0.1", "@waku/enr": "0.0.28-09108d9.0", "@waku/interfaces": "0.0.29-09108d9.0", "@waku/proto": "0.0.9-09108d9.0", "@waku/utils": "0.0.22-09108d9.0", "debug": "^4.3.4", "it-all": "^3.0.4", "it-length-prefixed": "^9.0.4", "it-pipe": "^3.0.1", "uint8arraylist": "^2.4.3", "uuid": "^9.0.0" }, "peerDependencies": { "@multiformats/multiaddr": "^12.0.0", "libp2p": "2.1.8" }, "optionalPeers": ["@multiformats/multiaddr", "libp2p"] }, "sha512-AyRDmFZCpcJuiz5UpSAwJNt8sZ25kdwHLrKO6PZ0qgRN4ZThp+dBxPQzwzXmsGOzn1THcirlkl0PZXkIy+u6pQ=="],
 
@@ -1304,6 +1317,8 @@
 
     "waku-dispatcher/check-error": ["check-error@1.0.3", "", { "dependencies": { "get-func-name": "^2.0.2" } }, "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg=="],
 
+    "waku-dispatcher/datastore-core": ["datastore-core@10.0.2", "", { "dependencies": { "@libp2p/logger": "^5.0.1", "interface-datastore": "^8.0.0", "interface-store": "^6.0.0", "it-drain": "^3.0.7", "it-filter": "^3.1.1", "it-map": "^3.1.1", "it-merge": "^3.0.5", "it-pipe": "^3.0.1", "it-pushable": "^3.2.3", "it-sort": "^3.0.6", "it-take": "^3.0.6" } }, "sha512-B3WXxI54VxJkpXxnYibiF17si3bLXE1XOjrJB7wM5co9fx2KOEkiePDGiCCEtnapFHTnmAnYCPdA7WZTIpdn/A=="],
+
     "waku-dispatcher/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
     "waku-dispatcher/deep-eql": ["deep-eql@4.1.4", "", { "dependencies": { "type-detect": "^4.0.0" } }, "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg=="],
@@ -1328,7 +1343,17 @@
 
     "waku-dispatcher/is-loopback-addr": ["is-loopback-addr@2.0.2", "", {}, "sha512-26POf2KRCno/KTNL5Q0b/9TYnL00xEsSaLfiFRmjM7m7Lw7ZMmFybzzuX4CcsLAluZGd+niLUiMRxEooVE3aqg=="],
 
+    "waku-dispatcher/is-network-error": ["is-network-error@1.1.0", "", {}, "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g=="],
+
+    "waku-dispatcher/is-plain-obj": ["is-plain-obj@2.1.0", "", {}, "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="],
+
     "waku-dispatcher/it-all": ["it-all@3.0.7", "", {}, "sha512-PkuYtu6XhJzuPTKXImd6y0qE6H91MUPV/b9xotXMAI6GjmD2v3NoHj2g5L0lS2qZ0EzyGWZU1kp0UxW8POvNBQ=="],
+
+    "waku-dispatcher/it-byte-stream": ["it-byte-stream@1.1.1", "", { "dependencies": { "it-queueless-pushable": "^1.0.0", "it-stream-types": "^2.0.2", "uint8arraylist": "^2.4.8" } }, "sha512-OIOb8PvK9ZV7MHvyxIDNyN3jmrxrJdx99G0RIYYb3Tzo1OWv+O1C6mfg7nnlDuuTQz2POYFXe87AShKAEl+POw=="],
+
+    "waku-dispatcher/it-drain": ["it-drain@3.0.8", "", {}, "sha512-eeOz+WwKc11ou1UuqZympcXPLCjpTn5ALcYFJiHeTEiYEZ2py/J1vq41XWYj88huCUiqp9iNHfObOKrbIk5Izw=="],
+
+    "waku-dispatcher/it-filter": ["it-filter@3.1.2", "", { "dependencies": { "it-peekable": "^3.0.0" } }, "sha512-2AozaGjIvBBiB7t7MpVNug9kwofqmKSpvgW7zhuyvCs6xxDd6FrfvqyfYtlQTKLNP+Io1WeXko1UQhdlK4M0gg=="],
 
     "waku-dispatcher/it-first": ["it-first@3.0.7", "", {}, "sha512-e2dVSlOP+pAxPYPVJBF4fX7au8cvGfvLhIrGCMc5aWDnCvwgOo94xHbi3Da6eXQ2jPL5FGEM8sJMn5uE8Seu+g=="],
 
@@ -1336,7 +1361,13 @@
 
     "waku-dispatcher/it-length-prefixed": ["it-length-prefixed@9.1.1", "", { "dependencies": { "it-reader": "^6.0.1", "it-stream-types": "^2.0.1", "uint8-varint": "^2.0.1", "uint8arraylist": "^2.0.0", "uint8arrays": "^5.0.1" } }, "sha512-O88nBweT6M9ozsmok68/auKH7ik/slNM4pYbM9lrfy2z5QnpokW5SlrepHZDKtN71llhG2sZvd6uY4SAl+lAQg=="],
 
+    "waku-dispatcher/it-length-prefixed-stream": ["it-length-prefixed-stream@1.2.1", "", { "dependencies": { "it-byte-stream": "^1.0.0", "it-stream-types": "^2.0.2", "uint8-varint": "^2.0.4", "uint8arraylist": "^2.4.8" } }, "sha512-FYqlxc2toUoK+aPO5r3KDBIUG1mOvk2DzmjQcsfLUTHRWMJP4Va9855tVzg/22Bj+VUUaT7gxBg7HmbiCxTK4w=="],
+
+    "waku-dispatcher/it-map": ["it-map@3.1.2", "", { "dependencies": { "it-peekable": "^3.0.0" } }, "sha512-G3dzFUjTYHKumJJ8wa9dSDS3yKm8L7qDUnAgzemOD0UMztwm54Qc2v97SuUCiAgbOz/aibkSLImfoFK09RlSFQ=="],
+
     "waku-dispatcher/it-merge": ["it-merge@3.0.9", "", { "dependencies": { "it-queueless-pushable": "^2.0.0" } }, "sha512-TjY4WTiwe4ONmaKScNvHDAJj6Tw0UeQFp4JrtC/3Mq7DTyhytes7mnv5OpZV4gItpZcs0AgRntpT2vAy2cnXUw=="],
+
+    "waku-dispatcher/it-parallel": ["it-parallel@3.0.9", "", { "dependencies": { "p-defer": "^4.0.1" } }, "sha512-FSg8T+pr7Z1VUuBxEzAAp/K1j8r1e9mOcyzpWMxN3mt33WFhroFjWXV1oYSSjNqcdYwxD/XgydMVMktJvKiDog=="],
 
     "waku-dispatcher/it-peekable": ["it-peekable@3.0.6", "", {}, "sha512-odk9wn8AwFQipy8+tFaZNRCM62riraKZJRysfbmOett9wgJumCwgZFzWUBUwMoiQapEcEVGwjDpMChZIi+zLuQ=="],
 
@@ -1344,15 +1375,25 @@
 
     "waku-dispatcher/it-pushable": ["it-pushable@3.2.3", "", { "dependencies": { "p-defer": "^4.0.0" } }, "sha512-gzYnXYK8Y5t5b/BnJUr7glfQLO4U5vyb05gPx/TyTw+4Bv1zM9gFk4YsOrnulWefMewlphCjKkakFvj1y99Tcg=="],
 
-    "waku-dispatcher/it-queueless-pushable": ["it-queueless-pushable@2.0.0", "", { "dependencies": { "abort-error": "^1.0.1", "p-defer": "^4.0.1", "race-signal": "^1.1.3" } }, "sha512-MlNnefWT/ntv5fesrHpxwVIu6ZdtlkN0A4aaJiE5wnmPMBv9ttiwX3UEMf78dFwIj5ZNaU9usYXg4swMEpUNJQ=="],
+    "waku-dispatcher/it-queueless-pushable": ["it-queueless-pushable@1.0.2", "", { "dependencies": { "p-defer": "^4.0.1", "race-signal": "^1.1.3" } }, "sha512-BFIm48C4O8+i+oVEPQpZ70+CaAsVUircvZtZCrpG2Q64933aLp+tDmas1mTBwqVBfIUUlg09d+e6SWW1CBuykQ=="],
 
     "waku-dispatcher/it-reader": ["it-reader@6.0.4", "", { "dependencies": { "it-stream-types": "^2.0.1", "uint8arraylist": "^2.0.0" } }, "sha512-XCWifEcNFFjjBHtor4Sfaj8rcpt+FkY0L6WdhD578SCDhV4VUm7fCkF3dv5a+fTcfQqvN9BsxBTvWbYO6iCjTg=="],
 
+    "waku-dispatcher/it-sort": ["it-sort@3.0.7", "", { "dependencies": { "it-all": "^3.0.0" } }, "sha512-PsaKSd2Z0uhq8Mq5htdfsE/UagmdLCLWdBXPwi3FZGR4BTG180pFamhK+O+luFtBCNGRoqKAdtbZGTyGwA9uzw=="],
+
     "waku-dispatcher/it-stream-types": ["it-stream-types@2.0.2", "", {}, "sha512-Rz/DEZ6Byn/r9+/SBCuJhpPATDF9D+dz5pbgSUyBsCDtza6wtNATrz/jz1gDyNanC3XdLboriHnOC925bZRBww=="],
+
+    "waku-dispatcher/it-take": ["it-take@3.0.7", "", {}, "sha512-0+EbsTvH1XCpwhhFkjWdqJTjzS5XP3KL69woBqwANNhMLKn0j39jk/WHIlvbg9XW2vEm7cZz4p8w5DkBZR8LoA=="],
 
     "waku-dispatcher/js-sha3": ["js-sha3@0.9.3", "", {}, "sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg=="],
 
+    "waku-dispatcher/libp2p": ["libp2p@2.1.8", "", { "dependencies": { "@libp2p/crypto": "^5.0.5", "@libp2p/interface": "^2.1.3", "@libp2p/interface-internal": "^2.0.8", "@libp2p/logger": "^5.1.1", "@libp2p/multistream-select": "^6.0.6", "@libp2p/peer-collections": "^6.0.8", "@libp2p/peer-id": "^5.0.5", "@libp2p/peer-store": "^11.0.8", "@libp2p/utils": "^6.1.1", "@multiformats/dns": "^1.0.6", "@multiformats/multiaddr": "^12.2.3", "@multiformats/multiaddr-matcher": "^1.2.1", "any-signal": "^4.1.1", "datastore-core": "^10.0.0", "interface-datastore": "^8.3.0", "it-byte-stream": "^1.0.12", "it-merge": "^3.0.5", "it-parallel": "^3.0.7", "merge-options": "^3.0.4", "multiformats": "^13.1.0", "p-defer": "^4.0.1", "p-retry": "^6.2.0", "progress-events": "^1.0.0", "race-event": "^1.3.0", "race-signal": "^1.0.2", "uint8arrays": "^5.1.0" } }, "sha512-OzUUgAs6983lP2FDqc3oABeUAyvd3iJ/BlYjwmjddpUwQO6gemuJFpWujagj2Vtj+oPosGrrPGWqv+WPnTkHUA=="],
+
     "waku-dispatcher/loupe": ["loupe@2.3.7", "", { "dependencies": { "get-func-name": "^2.0.1" } }, "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA=="],
+
+    "waku-dispatcher/merge-options": ["merge-options@3.0.4", "", { "dependencies": { "is-plain-obj": "^2.1.0" } }, "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ=="],
+
+    "waku-dispatcher/mortice": ["mortice@3.0.6", "", { "dependencies": { "observable-webworkers": "^2.0.1", "p-queue": "^8.0.1", "p-timeout": "^6.0.0" } }, "sha512-xUjsTQreX8rO3pHuGYDZ3PY/sEiONIzqzjLeog5akdY4bz9TlDDuvYlU8fm+6qnm4rnpa6AFxLhsfSBThLijdA=="],
 
     "waku-dispatcher/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -1360,9 +1401,13 @@
 
     "waku-dispatcher/netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
 
+    "waku-dispatcher/observable-webworkers": ["observable-webworkers@2.0.1", "", {}, "sha512-JI1vB0u3pZjoQKOK1ROWzp0ygxSi7Yb0iR+7UNsw4/Zn4cQ0P3R7XL38zac/Dy2tEA7Lg88/wIJTjF8vYXZ0uw=="],
+
     "waku-dispatcher/p-defer": ["p-defer@4.0.1", "", {}, "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A=="],
 
     "waku-dispatcher/p-queue": ["p-queue@8.1.0", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw=="],
+
+    "waku-dispatcher/p-retry": ["p-retry@6.2.1", "", { "dependencies": { "@types/retry": "0.12.2", "is-network-error": "^1.0.0", "retry": "^0.13.1" } }, "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ=="],
 
     "waku-dispatcher/p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
 
@@ -1375,6 +1420,8 @@
     "waku-dispatcher/race-event": ["race-event@1.3.0", "", {}, "sha512-kaLm7axfOnahIqD3jQ4l1e471FIFcEGebXEnhxyLscuUzV8C94xVHtWEqDDXxll7+yu/6lW0w1Ff4HbtvHvOHg=="],
 
     "waku-dispatcher/race-signal": ["race-signal@1.1.3", "", {}, "sha512-Mt2NznMgepLfORijhQMncE26IhkmjEphig+/1fKC0OtaKwys/gpvpmswSjoN01SS+VO951mj0L4VIDXdXsjnfA=="],
+
+    "waku-dispatcher/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "waku-dispatcher/supports-color": ["supports-color@9.4.0", "", {}, "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw=="],
 
@@ -1473,6 +1520,10 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "waku-dispatcher/@libp2p/multistream-select/it-length-prefixed": ["it-length-prefixed@10.0.1", "", { "dependencies": { "it-reader": "^6.0.1", "it-stream-types": "^2.0.1", "uint8-varint": "^2.0.1", "uint8arraylist": "^2.0.0", "uint8arrays": "^5.0.1" } }, "sha512-BhyluvGps26u9a7eQIpOI1YN7mFgi8lFwmiPi07whewbBARKAG9LE09Odc8s1Wtbt2MB6rNUrl7j9vvfXTJwdQ=="],
+
+    "waku-dispatcher/it-merge/it-queueless-pushable": ["it-queueless-pushable@2.0.0", "", { "dependencies": { "abort-error": "^1.0.1", "p-defer": "^4.0.1", "race-signal": "^1.1.3" } }, "sha512-MlNnefWT/ntv5fesrHpxwVIu6ZdtlkN0A4aaJiE5wnmPMBv9ttiwX3UEMf78dFwIj5ZNaU9usYXg4swMEpUNJQ=="],
 
     "waku-dispatcher/weald/ms": ["ms@3.0.0-canary.1", "", {}, "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="],
 

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@tanstack/react-query": "^5.56.2",
     "@waku/sdk": "0.0.30-09108d9.0",
+    "@waku/message-encryption": "0.0.32-09108d9.0",
     "caniuse-lite": "^1.0.30001706",
-
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/src/components/FormResponse.tsx
+++ b/src/components/FormResponse.tsx
@@ -4,7 +4,7 @@ import { Send, Lock, AlertTriangle, Check } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { FormSubmissionParams, FormType } from '@/types/form';
 import { getConnectedWallet, signMessage } from '@/lib/wallet';
-import { loadResponse, submitResponse, toHexString } from '@/lib/formStore';
+import { loadResponse, submitAndPersistResponse, submitResponse, toHexString } from '@/lib/formStore';
 import { useWakuContext } from '@/hooks/useWaku';
 import { randomBytes } from 'ethers';
 
@@ -124,7 +124,7 @@ const FormResponse: React.FC<FormResponseProps> = ({ form, onSubmitted }) => {
       }
       
       // Submit the response with the wallet address
-      const response = await submitResponse({
+      const response = await submitAndPersistResponse({
         formId: form.id,
         respondent: walletAddress,
         answers: formattedAnswers,

--- a/src/components/FormResponse.tsx
+++ b/src/components/FormResponse.tsx
@@ -1,11 +1,13 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Send, Lock, AlertTriangle, Check } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { FormSubmissionParams, FormType } from '@/types/form';
 import { getConnectedWallet, signMessage } from '@/lib/wallet';
-import { submitResponse } from '@/lib/formStore';
+import { loadResponse, submitResponse, toHexString } from '@/lib/formStore';
 import { useWakuContext } from '@/hooks/useWaku';
+import { randomBytes } from 'ethers';
+
 
 interface FormResponseProps {
   form: FormType;
@@ -19,6 +21,15 @@ const FormResponse: React.FC<FormResponseProps> = ({ form, onSubmitted }) => {
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (form) {
+      const response = loadResponse(form.id)
+      if (response) {
+        setSubmitted(true)
+      }
+    }
+  },[form])
 
   const handleInputChange = (questionId: string, value: string | string[]) => {
     setAnswers({
@@ -117,6 +128,8 @@ const FormResponse: React.FC<FormResponseProps> = ({ form, onSubmitted }) => {
         formId: form.id,
         respondent: walletAddress,
         answers: formattedAnswers,
+        submittedAt: Date.now(),
+        confirmationId: toHexString(randomBytes(32)),
       });
       
       // Simulate encryption and network delay

--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -10,6 +10,7 @@ import {
   getNetwork, 
   getENS
 } from '@/lib/wallet';
+import { useWakuContext } from '@/hooks/useWaku';
 
 const WalletConnect: React.FC = () => {
   const [isConnected, setIsConnected] = useState(false);

--- a/src/config/waku.ts
+++ b/src/config/waku.ts
@@ -1,0 +1,1 @@
+export const CONTENT_TOPIC = "/whisperbox/1/all/json"

--- a/src/hooks/useFormResponseNotifications.tsx
+++ b/src/hooks/useFormResponseNotifications.tsx
@@ -52,7 +52,7 @@ export const useFormResponseNotifications = () => {
               </button>
             </div>
           ),
-                    variant: "default",
+          variant: "default",
         });
       }
     };

--- a/src/hooks/useWaku.tsx
+++ b/src/hooks/useWaku.tsx
@@ -12,6 +12,7 @@ import {
     Protocols
 } from "@waku/interfaces"
 import { WakuClient } from "@/lib/waku";
+import { getConnectedWallet } from "@/lib/wallet";
 
 export type WakuInfo = {
     client: WakuClient | undefined
@@ -61,11 +62,13 @@ export const WakuContextProvider = ({ children, updateStatus }: Props) => {
     const [node, setNode] = useState<LightNode>()
     const [health, setHealth] = useState<HealthStatus>(HealthStatus.Unhealthy)
     const [ client, setClient ] = useState<WakuClient | undefined>(undefined)
+    const address = getConnectedWallet();
+
 
 
     useEffect(() => {
         (async () => {
-            if (connected || connecting || node) return
+            if (connected || connecting || node || !address) return
             setConnecting(true)
             setStatus("starting")
             updateStatus("Starting Waku node", "info", 2000)
@@ -91,6 +94,7 @@ export const WakuContextProvider = ({ children, updateStatus }: Props) => {
                         })
 
                     const c = new WakuClient(ln);
+                    c.setAddress(address)
                     await c.init()
                     setClient(c)
                     setStatus("connected")

--- a/src/lib/formStore.ts
+++ b/src/lib/formStore.ts
@@ -1,11 +1,15 @@
 // This is a temporary in-memory store for demonstration purposes
 // In a real implementation, this would be stored encrypted and distributed
 
-import { FormType, FormResponse, FormCreationParams, FormSubmissionParams } from '@/types/form';
+import { FormType, FormResponse, FormCreationParams, FormSubmissionParams, FormKeys } from '@/types/form';
 import { checkNFTOwnership, getENS } from './wallet';
 import { FORM_CONFIG } from '@/config/form';
 import { sha256 } from 'ethers';
-import { utf8ToBytes} from "@waku/sdk"
+import { bytesToUtf8, utf8ToBytes} from "@waku/sdk"
+import { generatePrivateKey, getPublicKey } from "@waku/message-encryption";
+import { utils } from "@noble/secp256k1"
+
+
 
 // In-memory store
 let forms: FormType[] = [];
@@ -16,21 +20,51 @@ export const formId = (form: FormType): string => {
 // Create a new form
 export const createForm = (form: FormCreationParams): FormType => {
   const ts = Date.now()
+  const privateKey = generatePrivateKey()
   const newForm: FormType = {
     ...form,
     id: "",
     createdAt: ts,
     responses: [],
+    privateKey: toHexString(privateKey),
+    publicKey: toHexString(getPublicKey(privateKey)),
+    confirmations: []
   };
 
   newForm.id = formId(newForm);
+  persistFormPrivateKey(newForm.id, newForm.privateKey)
   
   forms = [...forms, newForm];
   return newForm;
 };
 
 export const addForm = (form: FormType) => {
+  try {
+    form.privateKey = loadFormPrivateKey(form.id)
+  } catch (e) {
+    console.log("Did not find form key", form.id)
+  }
+
+  const response = loadResponse(form.id)
+  if (response) {
+    console.log("Found a response!!")
+    form.responses.push({...response, id: "", respondentENS: ""}) //FIXME
+  }
   forms = [...forms, form];
+}
+
+export const addConfirmation = (formId: string, confirmationId: string) => {
+  const form = getFormById(formId)
+  if (!form) {
+    throw new Error("Form not found")
+  }
+
+  const confirmationIndex = form.confirmations.findIndex(c => c == confirmationId)
+  if (confirmationIndex > -1) {
+    return
+  }
+
+  form.confirmations.push(confirmationId)
 }
 
 // Get all forms
@@ -67,13 +101,14 @@ export const submitResponse = async (response: FormSubmissionParams): Promise<Fo
   const newResponse: FormResponse = {
     ...response,
     id: `r${Date.now()}`,
-    submittedAt: Date.now(),
     respondentENS: await getENS(response.respondent),
   };
   
   if (forms[formIndex].responses.findIndex(r => r.respondent.toLowerCase() == response.respondent.toLowerCase()) != -1) {
     throw new Error('Response already exists for this respondent');
   }
+
+  persistResponse(newResponse)
 
   // Add the response to the form
   forms[formIndex].responses.push(newResponse);
@@ -145,3 +180,70 @@ export const hasResponded = (formId: string, userAddress: string | null): boolea
   
   return false;
 }; 
+
+const storageKey = "whisperbox_formKeys"
+
+export const persistFormPrivateKey = (formId: string, privateKey: string): void =>  {
+    let formKeys:FormKeys[] = JSON.parse(localStorage.getItem(storageKey) || "[]")
+  
+    const formIndex = formKeys.findIndex(f => f.id == formId)
+
+    if (formIndex >= 0) {
+      throw new Error("Form key already stored")
+    }
+
+    formKeys = [...formKeys, {id: formId, privateKey: privateKey}]
+    localStorage.setItem(storageKey, JSON.stringify(formKeys))
+}
+
+export const loadFormPrivateKey = (formId: string): string => {
+    let formKeys:FormKeys[] = JSON.parse(localStorage.getItem(storageKey) || "[]")
+    
+    const formIndex = formKeys.findIndex(f => f.id == formId)
+
+    if (formIndex < 0) {
+      throw new Error("Form does not exists")
+    }
+
+    return formKeys[formIndex].privateKey
+}
+
+
+const responseKey = "whisperbox_response"
+export const persistResponse = (response: FormSubmissionParams): void =>  {
+  let responses:FormSubmissionParams[] = JSON.parse(localStorage.getItem(responseKey) || "[]")
+
+  const formIndex = responses.findIndex(f => f.formId == response.formId)
+
+  if (formIndex >= 0) {
+    throw new Error("Response already exists")
+  }
+
+  responses = [...responses, response]
+  localStorage.setItem(responseKey, JSON.stringify(responses))
+}
+
+export const loadResponse = (formId: string): FormSubmissionParams | undefined => {
+  let responses:FormSubmissionParams[] = JSON.parse(localStorage.getItem(responseKey) || "[]")
+  
+  const formIndex = responses.findIndex(f => f.formId == formId)
+
+  if (formIndex < 0) {
+    return
+  }
+
+  return responses[formIndex]
+}
+
+export function toHexString(byteArray: Uint8Array) {
+  return Array.prototype.map.call(byteArray, function(byte) {
+    return ('0' + (byte & 0xFF).toString(16)).slice(-2);
+  }).join('');
+}
+export function toByteArray(hexString: string) {
+  var result = [];
+  for (var i = 0; i < hexString.length; i += 2) {
+    result.push(parseInt(hexString.substr(i, 2), 16));
+  }
+  return result;
+}

--- a/src/lib/formStore.ts
+++ b/src/lib/formStore.ts
@@ -197,7 +197,7 @@ export const persistFormPrivateKey = (formId: string, privateKey: string): void 
 }
 
 export const loadFormPrivateKey = (formId: string): string => {
-    let formKeys:FormKeys[] = JSON.parse(localStorage.getItem(storageKey) || "[]")
+    const formKeys:FormKeys[] = JSON.parse(localStorage.getItem(storageKey) || "[]")
     
     const formIndex = formKeys.findIndex(f => f.id == formId)
 
@@ -224,7 +224,7 @@ export const persistResponse = (response: FormSubmissionParams): void =>  {
 }
 
 export const loadResponse = (formId: string): FormSubmissionParams | undefined => {
-  let responses:FormSubmissionParams[] = JSON.parse(localStorage.getItem(responseKey) || "[]")
+  const responses:FormSubmissionParams[] = JSON.parse(localStorage.getItem(responseKey) || "[]")
   
   const formIndex = responses.findIndex(f => f.formId == formId)
 
@@ -241,8 +241,8 @@ export function toHexString(byteArray: Uint8Array) {
   }).join('');
 }
 export function toByteArray(hexString: string) {
-  var result = [];
-  for (var i = 0; i < hexString.length; i += 2) {
+  const result = [];
+  for (let i = 0; i < hexString.length; i += 2) {
     result.push(parseInt(hexString.substr(i, 2), 16));
   }
   return result;

--- a/src/lib/formStore.ts
+++ b/src/lib/formStore.ts
@@ -108,13 +108,20 @@ export const submitResponse = async (response: FormSubmissionParams): Promise<Fo
     throw new Error('Response already exists for this respondent');
   }
 
-  persistResponse(newResponse)
 
   // Add the response to the form
   forms[formIndex].responses.push(newResponse);
   
   return newResponse;
 };
+
+export const submitAndPersistResponse = async (response: FormSubmissionParams): Promise<FormResponse> => {
+  const newResponse = await submitResponse(response)
+
+  persistResponse(newResponse)
+
+  return newResponse
+}
 
 // Delete a form
 export const deleteForm = (id: string): void => {

--- a/src/lib/waku.ts
+++ b/src/lib/waku.ts
@@ -148,7 +148,7 @@ export class WakuClient extends EventEmitter {
             submitResponse(response)
             await this.publishConfirmation(response)
 
-            this.emit(ClientEvents.NEW_RESPONSE, { form, response: payload });
+            this.emit(ClientEvents.NEW_RESPONSE, { form, response: response });
         }
     }
 

--- a/src/lib/waku.ts
+++ b/src/lib/waku.ts
@@ -1,8 +1,12 @@
 import EventEmitter from "events"
-import getDispatcher, { Dispatcher, DispatchMetadata, Signer} from "waku-dispatcher"
-import {  IWaku, Protocols  } from "@waku/sdk";
-import { addForm,  getAllForms, getFormById, submitResponse } from "./formStore";
-import { FormSubmissionParams, FormType } from "@/types";
+import getDispatcher, { destroyDispatcher, Dispatcher, DispatchMetadata, Key, KeyType, Signer} from "waku-dispatcher"
+import { bytesToUtf8, createEncoder, IWaku, LightNode, Protocols, utf8ToBytes,  } from "@waku/sdk";
+import { addConfirmation, addForm, createForm, getAllForms, getFormById, getFormsByCreator, submitResponse, toByteArray, toHexString } from "./formStore";
+import { FormSubmissionParams, FormType, ResponseConfirmation } from "@/types";
+import { utils } from "@noble/secp256k1"
+import { ResponseType } from "@/types/waku";
+import { decryptAsymmetric, encryptAsymmetric } from "@waku/message-encryption/ecies";
+
 
 
 export enum ClientState {
@@ -19,6 +23,7 @@ export enum ClientEvents {
 export enum MessageTypes {
     NEW_FORM = "new_form",
     FORM_RESPONSE = "form_response",
+    CONFIRMATION_RESPONSE = "confirmation_response"
 }
 
 const CONTENT_TOPIX = "/whisperbox/1/all/json"
@@ -29,6 +34,7 @@ export class WakuClient extends EventEmitter {
 
     node:IWaku | undefined = undefined
     dispatcher:Dispatcher | null = null
+    address:string | undefined = undefined
 
 
     constructor(node:IWaku | undefined) {
@@ -52,14 +58,14 @@ export class WakuClient extends EventEmitter {
                 if (!disp) {
                     throw new Error("Failed to initialize Waku Dispatcher")
                 }
-                this.dispatcher = disp 
-        
+                this.dispatcher = disp
+
                 this.emit(ClientEvents.STATE_UPDATE, this.state)
-        
+
                 this.state = ClientState.INITIALIZED
                 this.emit(ClientEvents.STATE_UPDATE, this.state)
 
-                
+
             }
             if (!this.dispatcher) {
                 this.state = ClientState.FAILED
@@ -70,21 +76,23 @@ export class WakuClient extends EventEmitter {
 
             this.dispatcher.on(MessageTypes.NEW_FORM, this.handleNewForm.bind(this))
             this.dispatcher.on(MessageTypes.FORM_RESPONSE, this.handleResponse.bind(this))
+            this.dispatcher.on(MessageTypes.CONFIRMATION_RESPONSE, this.handleConfirmation.bind(this))
+
 
             await this.dispatcher.start()
             try {
                 await this.node!.waitForPeers([Protocols.Store]);
-    
+
                 console.log("Dispatching local query")
-                await this.dispatcher.dispatchLocalQuery() 
-    
-    
+                await this.dispatcher.dispatchLocalQuery()
+
+
                 if (getAllForms.length == 0) {
                     console.log("Dispatching general query")
                     await this.dispatcher.dispatchQuery()
-        
+
                 }
-    
+
 //                this.emit(ClientEvents.STATE_UPDATE, ClientState.INIT_PROTOCOL)
             } catch (e) {
                 console.error("Failed to initialized protocol:", e)
@@ -100,25 +108,56 @@ export class WakuClient extends EventEmitter {
         }
     }
 
+    public setAddress(address: string):void {
+        this.address = address
+    }
+
     private handleNewForm(payload: FormType, signer: Signer, _3:DispatchMetadata): void {
-        console.log("Got a new form: ", payload.title, getFormById(payload.id))
-        if(!getFormById(payload.id)) {
+        const form = getFormById(payload.id)
+
+        if(!form) {
             addForm(payload)
         }
     }
 
-    private handleResponse(payload: FormSubmissionParams, signer: Signer, _3:DispatchMetadata): void {
-        console.log("Got a response for form: ", payload.formId, getFormById(payload.formId))
-        const form = getFormById(payload.formId);
-        if(form) {
-            console.log("Adding response", payload)
-            try {
-                const response = submitResponse(payload);
-                // Emit an event with the response and form data for notifications
-                this.emit(ClientEvents.NEW_RESPONSE, { form, response: payload });
-            } catch (error) {
-                console.error("Error submitting response:", error);
+    private async handleResponse(payload: FormSubmissionParams | ResponseType, signer: Signer, _3:DispatchMetadata): Promise<void> {
+        let response: FormSubmissionParams  | null = null
+        if ((payload as ResponseType).payload) {
+            const forms = getFormsByCreator(this.address!)
+            for (const form of forms) {
+                if (!form.privateKey) continue
+                try {
+                    const data = await decryptAsymmetric(new Uint8Array(toByteArray((payload as ResponseType).payload)), new Uint8Array(toByteArray(form.privateKey)))
+                    response = JSON.parse(bytesToUtf8(data)) as FormSubmissionParams
+                } catch (e) {
+                    console.log(e)
+                }
             }
+
+        } else {
+            response = payload as FormSubmissionParams
+        }
+
+        if (!response) {
+            console.error("Failed to match response with a form")
+            return
+        }
+        const form = getFormById(response.formId)
+
+        if(form && form.creator == this.address) {
+
+            submitResponse(response)
+            await this.publishConfirmation(response)
+
+            this.emit(ClientEvents.NEW_RESPONSE, { form, response: payload });
+        }
+    }
+
+    private handleConfirmation(payload: ResponseConfirmation, signer: Signer, _3:DispatchMetadata): void {
+        const form = getFormById(payload.formId)
+
+        if(form) {
+            addConfirmation(payload.formId, payload.confirmationId)
         }
     }
 
@@ -126,7 +165,11 @@ export class WakuClient extends EventEmitter {
         if (this.dispatcher == null) {
             throw new Error("Dispatcher is not initialized")
         }
-        const result = await this.dispatcher.emit(MessageTypes.NEW_FORM, form)
+
+        const formToPublish = JSON.parse(JSON.stringify(form));
+        formToPublish.privateKey = ""
+
+        const result = await this.dispatcher.emit(MessageTypes.NEW_FORM, formToPublish)
         return result != false
     }
 
@@ -135,8 +178,32 @@ export class WakuClient extends EventEmitter {
             throw new Error("Dispatcher is not initialized")
         }
 
-        console.log(response)
-        const result = await this.dispatcher.emit(MessageTypes.FORM_RESPONSE, response)
+        const form = getFormById(response.formId)
+        if (!form) {
+            throw new Error("Form not found")
+        }
+
+        const encrypted = await encryptAsymmetric(utf8ToBytes(JSON.stringify(response)), new Uint8Array(toByteArray(form.publicKey)))
+
+        const result = await this.dispatcher.emit(MessageTypes.FORM_RESPONSE, {payload: toHexString(encrypted)} as ResponseType)
+        return result != false
+    }
+
+    public async publishConfirmation(response: FormSubmissionParams): Promise<boolean> {
+        if (this.dispatcher == null) {
+            throw new Error("Dispatcher is not initialized")
+        }
+
+        const form = getFormById(response.formId)
+        if (!form) {
+            throw new Error("Form not found")
+        }
+
+        if (!response.confirmationId) {
+            return true
+        }
+
+        const result = await this.dispatcher.emit(MessageTypes.CONFIRMATION_RESPONSE, {formId: response.formId, confirmationId: response.confirmationId} as ResponseConfirmation)
         return result != false
     }
 }

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -208,7 +208,7 @@ const View: React.FC = () => {
                 
                 <div className="flex items-center text-sm text-muted-foreground">
                   <User className="w-4 h-4 mr-1.5" />
-                  {form.responses.length} responses
+                  {form.confirmations.length} responses
                 </div>
                 
                 {form.whitelist.type === 'none' ? (

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -15,6 +15,8 @@ export interface FormType {
   title: string;
   description: string;
   creator: string;
+  publicKey: string;
+  privateKey: string;
   createdAt: number;
   expiresAt?: string; // Optional expiry timestamp
   questions: FormQuestion[];
@@ -23,6 +25,7 @@ export interface FormType {
     value: string; // NFT contract address or comma-separated list of addresses or empty string for none
   };
   responses: FormResponse[];
+  confirmations: string[];
 }
 
 export interface FormResponse {
@@ -35,10 +38,21 @@ export interface FormResponse {
     questionId: string;
     value: string | string[];
   }[];
+  confirmationId: string | null;
+}
+
+export interface ResponseConfirmation {
+  formId: string;
+  confirmationId: string;
+}
+
+export interface FormKeys {
+  id: string,
+  privateKey: string
 }
 
 // Form creation parameter type (omitting generated fields)
-export type FormCreationParams = Omit<FormType, 'id' | 'responses' | 'createdAt'>;
+export type FormCreationParams = Omit<FormType, 'id' | 'responses' | 'createdAt' | 'publicKey' | 'privateKey' | 'confirmations'>;
 
 // Form submission parameter type (omitting generated fields)
-export type FormSubmissionParams = Omit<FormResponse, 'id' | 'submittedAt' | 'respondentENS'>; 
+export type FormSubmissionParams = Omit<FormResponse, 'id' | 'respondentENS'>;

--- a/src/types/waku.ts
+++ b/src/types/waku.ts
@@ -1,0 +1,3 @@
+export interface ResponseType {
+    payload: string;
+}

--- a/src/types/waku.ts
+++ b/src/types/waku.ts
@@ -1,3 +1,3 @@
-export interface ResponseType {
-    payload: string;
+export interface EncryptedFormSubmissionParams {
+    encryptedPayload: string;
 }


### PR DESCRIPTION
This PR

1. Adds public key to Form message + stores private key per Form locally
2. Encrypts responses using the public key in Form message + stores responses for respondent in localStorage
3. Adds `confirmationId` to response type and generates the value randomly upon response publishing
4. Publishes "response_confirmation" message with the `confirmationId`, so that respondent can verify creator received their response and anyone can calculate number of responses for a given form based on # of confirmation messages