### PR TITLE
limit which formmessages to process, store processed forms in local storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "waku-dispatcher": "0.0.20-dev",
+    "waku-dispatcher": "0.0.21-dev",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Navbar from './Navbar';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 import { useFormResponseNotifications } from '@/hooks/useFormResponseNotifications';
+import { useWakuContext } from '@/hooks/useWaku';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -10,6 +11,9 @@ interface LayoutProps {
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   const location = useLocation();
+  const { id } = useParams<{ id: string }>();
+  const {client} = useWakuContext()
+ 
 
   useFormResponseNotifications();
   
@@ -33,6 +37,13 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     ease: 'anticipate',
     duration: 0.5,
   };
+
+  useEffect(() => {
+    if (!client ) return
+
+    console.log("Setting the id!!!!")
+    client.setCurrentFormId(id)
+  }, [client, id])
 
   return (
     <div className="min-h-screen flex flex-col">

--- a/src/hooks/useWaku.tsx
+++ b/src/hooks/useWaku.tsx
@@ -94,9 +94,9 @@ export const WakuContextProvider = ({ children, updateStatus }: Props) => {
                         })
 
                     const c = new WakuClient(ln);
+                    setClient(c)
                     c.setAddress(address)
                     await c.init()
-                    setClient(c)
                     setStatus("connected")
                     setConnected(true)
                     setConnecting(false)

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -6,13 +6,15 @@ import FormResponse from '@/components/FormResponse';
 import NFTGate from '@/components/NFTGate';
 import { 
   getFormById, 
-  canAccessForm, 
-  hasResponded 
+  hasResponded, 
+  canAccessFormById,
+  updateStoredForm,
+  loadStoredForm
 } from '@/lib/formStore';
 import { getConnectedWallet } from '@/lib/wallet';
 import AnimatedTransition from '@/components/AnimatedTransition';
 import { useToast } from '@/hooks/use-toast';
-import { FormType } from '@/types';
+import { FormType, StoredFormType } from '@/types';
 import { useWakuContext } from '@/hooks/useWaku';
 
 const View: React.FC = () => {
@@ -81,12 +83,19 @@ const View: React.FC = () => {
           setHasAccess(true);
         } else {
           // Check if user has access to the form
-          const access = await canAccessForm(id, wallet);
+          const access = await canAccessFormById(id, wallet);
           setHasAccess(access);
           
           // Check if user has already responded
           const responded = hasResponded(id, wallet);
           setHasAlreadyResponded(responded);
+        }
+      }
+
+      if (foundForm.id == id) {
+        const storedForm = loadStoredForm(id)
+        if (storedForm.type == StoredFormType.ACCESSIBLE) {
+          updateStoredForm(id, StoredFormType.VIEWED)
         }
       }
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -46,9 +46,17 @@ export interface ResponseConfirmation {
   confirmationId: string;
 }
 
-export interface FormKeys {
+export interface StoredForm {
   id: string,
   privateKey: string
+  type: StoredFormType
+}
+
+export enum StoredFormType {
+  ACCESSIBLE = 'accessible',
+  VIEWED = 'viewed',
+  PARTICIPATED = 'participated',
+  CREATOR = 'creator'
 }
 
 // Form creation parameter type (omitting generated fields)


### PR DESCRIPTION
This PR 

* Updates Waku Dispatcher (needs `npm install` or `bun install`)
* Limits which forms are actually loaded in memory and persisted in IndexedDB (to avoid/minimize spam risk)
* Add various form stages in `My Forms` view - my forms, participated forms, viewed forms and forms for me 